### PR TITLE
fix: missing file error on multiple transform-values steps

### DIFF
--- a/pkg/helm-wrapper/helm_wrapper.go
+++ b/pkg/helm-wrapper/helm_wrapper.go
@@ -205,6 +205,12 @@ func (c *HelmWrapper) RunHelm() {
 					return
 				}
 				if filename == "" {
+					// This is not a -f or --values parameter
+					continue
+				}
+				if strings.HasPrefix(filename, c.temporaryDirectory) {
+					// If we get here that means this file was pre-processed by something else.
+					// We must skip it, otherwise we will consume the fifo-pipe
 					continue
 				}
 


### PR DESCRIPTION
If `HELMWRAP_CONFIG` has multiple transform-values steps with filters:

```json
[
    {
        "action": "transform-values",
        "filter": "$.sops.lastmodified",
        "command": "sops -d {}"
    },
    {
        "action": "transform-values",
        "filter": "$.Kustomize",
        "command": "extract-kustomize {}"
    }
]
```

The second transform-values will consume the fifo data because it reads the file looking for the filter path resulting in the following error:

```
Error: open /tmp/helm.4124330597/7ac4790b8518a5d1e300578ef579df2e891bdb978f80aa0cc2a8cb18aeeedbbc: no such file or directory
Error: open /tmp/helm.4124330597/7ac4790b8518a5d1e300578ef579df2e891bdb978f80aa0cc2a8cb18aeeedbbc: no such file or directory
[helm-wrap] Error: failed to run Helm: exit status 1
```

The easiest fix here is to just not allow re-processing of transformed files.  This does prevent chaining transform tools together, but I don't know of any real-world use cases for that.
